### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/Workshop1/S3/bootstrap/cfn-template.json
+++ b/Workshop1/S3/bootstrap/cfn-template.json
@@ -293,7 +293,7 @@
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "Handler": "index.handler",
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 60,
         "Role": {
           "Fn::GetAtt": [ "IamLambdaExecutionRoleFullAccess", "Arn" ]


### PR DESCRIPTION
CloudFormation templates in aws-lambda-edge-workshops have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.