### PR TITLE
Upgrade to Node.js 12.x

### DIFF
--- a/Workshop1/Lab1_Security/README.md
+++ b/Workshop1/Lab1_Security/README.md
@@ -57,7 +57,7 @@ In the `Create function` page, specify:
 Field | Value
 --- | ---
 Name | ws-lambda-at-edge-add-security-headers
-Runtime | Node.js 8.10
+Runtime | Node.js 12.x
 Role | Choose an existing role
 Existing role | ws-lambda-at-edge-basic-<UNIQUE_ID>
 

--- a/Workshop1/Lab2_ContentGeneration/README.md
+++ b/Workshop1/Lab2_ContentGeneration/README.md
@@ -46,7 +46,7 @@ In the `Create function` page, specify:
 Field | Value
 --- | ---
 Name | `ws-lambda-at-edge-generate-card-page`
-Runtime | `Node.js 8.10`
+Runtime | `Node.js 12.x`
 Role | `Choose an existing role`
 Existing role | `ws-lambda-at-edge-read-only-<UNIQUE_ID>`
 
@@ -165,7 +165,7 @@ In the `Create function` page, specify:
 Field | Value
 --- | ---
 Name | `ws-lambda-at-edge-generate-home-page`
-Runtime | `Node.js 8.10`
+Runtime | `Node.js 12.x`
 Role | `Choose an existing role`
 Existing role | `ws-lambda-at-edge-read-only-<UNIQUE_ID>`
 

--- a/Workshop1/Lab3_SimpleAPI/README.md
+++ b/Workshop1/Lab3_SimpleAPI/README.md
@@ -53,7 +53,7 @@ In the `Create function` page, specify:
 Field | Value
 --- | ---
 Name | `ws-lambda-at-edge-api-like`
-Runtime | `Node.js 8.10`
+Runtime | `Node.js 12.x`
 Role | `Choose an existing role`
 Existing role | `ws-lambda-at-edge-full-access-<UNIQUE_ID>` (this role allows the function to update the DynamoDB table)
 

--- a/Workshop1/Lab4_PrettyUrls/README.md
+++ b/Workshop1/Lab4_PrettyUrls/README.md
@@ -74,7 +74,7 @@ In the `Create function` page, specify:
 Field | Value
 --- | ---
 Name | `ws-lambda-at-edge-redirect`
-Runtime | `Node.js 8.10`
+Runtime | `Node.js 12.x`
 Role | `Choose an existing role`
 Existing role | `ws-lambda-at-edge-basic-<UNIQUE_ID>`
 

--- a/Workshop1/Lab5_Customization/README.md
+++ b/Workshop1/Lab5_Customization/README.md
@@ -61,7 +61,7 @@ In the `Create function` page, specify:
 Field | Value
 --- | ---
 Name | `ws-lambda-at-edge-customize-css`
-Runtime | `Node.js 8.10`
+Runtime | `Node.js 12.x`
 Role | `Choose an existing role`
 Existing role | `ws-lambda-at-edge-basic-<UNIQUE_ID>`
 

--- a/Workshop1/S3/bootstrap/cfn-template.json
+++ b/Workshop1/S3/bootstrap/cfn-template.json
@@ -293,7 +293,7 @@
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "Handler": "index.handler",
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs12.x",
         "Timeout": 60,
         "Role": {
           "Fn::GetAtt": [ "IamLambdaExecutionRoleFullAccess", "Arn" ]


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Upgrading to latest version of Node.js supported for Lambda@Edge. Node.js 6 is no longer supported for function creation.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
