### PR TITLE
Upgrade deprecated runtime nodejs12.x

### DIFF
--- a/Workshop1/S3/bootstrap/cfn-template.json
+++ b/Workshop1/S3/bootstrap/cfn-template.json
@@ -293,7 +293,7 @@
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "Handler": "index.handler",
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs16.x",
         "Timeout": 60,
         "Role": {
           "Fn::GetAtt": [ "IamLambdaExecutionRoleFullAccess", "Arn" ]


### PR DESCRIPTION
CloudFormation templates in aws-lambda-edge-workshops have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs12.x). The affected templates have been updated to a supported runtime (nodejs16.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.